### PR TITLE
Adding api calls for movie images

### DIFF
--- a/Frontend/src/components/movieCard/movieCard.styles.ts
+++ b/Frontend/src/components/movieCard/movieCard.styles.ts
@@ -1,36 +1,25 @@
-import { Typography } from "@mui/material";
-import { Box } from "@mui/system";
+import { Grid, Typography } from "@mui/material";
 import styled from "styled-components";
 
-export const MovieCardWrapper = styled(Box)`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  margin: 2rem 0;
-  padding: 1rem;
-  border-radius: 1rem;
-  background-color: #fff;
-  box-shadow: 0 0 0.5rem 0.1rem rgba(0, 0, 0, 0.1);
-  transition: all 0.2s ease-in-out;
-  cursor: pointer;
-  &:hover {
-    transform: scale(1.05);
+const loadingStyles = `
+  background: #eee;
+  background: linear-gradient(110deg, #ececec 8%, #f5f5f5 18%, #ececec 33%);
+  border-radius: 5px;
+  background-size: 200% 100%;
+  animation: 1.5s shine linear infinite;
+  @keyframes shine {
+    to {
+      background-position: 200% center;
+    }
   }
 `;
 
-export const MovieTitle = styled(Typography)`
-  margin: 0.5rem 0;
-  font-size: 1.5rem;
-  font-weight: 600;
-  text-align: center;
-`;
-
-export const MovieInfoWrapper = styled(Box)`
+export const MovieGridWrapper = styled(Grid)`
   width: calc(100% - 2rem);
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-areas:
+    "title title"
     "image info"
     "image info"
     "image info"
@@ -44,24 +33,55 @@ export const MovieInfoWrapper = styled(Box)`
   @media (max-width: 768px) {
     grid-template-columns: repeat(1, 1fr);
     grid-template-areas:
+      "title"
       "image"
       "info"
       "button";
   }
 `;
 
+export const MovieTitle = styled(Typography)`
+  grid-area: title;
+  margin: 0.5rem 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+`;
+
+export const MovieTitleLoading = styled.div`
+  height: 3rem;
+  grid-area: title;
+  ${loadingStyles}
+`;
+
 export const MovieImage = styled.img`
   grid-area: image;
-  width: 100%;
-  height: 100%;
+  width: 200px;
+  height: 250px;
   object-fit: cover;
   border-radius: 1rem;
 `;
 
+export const MovieImageLoading = styled.div`
+  grid-area: image;
+  width: 200px;
+  height: 250px;
+  ${loadingStyles}
+`;
+
 export const MovieInfo = styled(Typography)`
   grid-area: info;
-  margin: 0 0.5rem;
   font-size: 1rem;
   font-weight: 400;
   text-align: center;
+`;
+
+export const MovieInfoLoading = styled.div`
+  grid-area: info;
+  ${loadingStyles}
+`;
+
+export const MovieButtonLoading = styled.div`
+  grid-area: button;
+  ${loadingStyles}
 `;

--- a/Frontend/src/components/movieCard/movieCard.tsx
+++ b/Frontend/src/components/movieCard/movieCard.tsx
@@ -1,25 +1,44 @@
-import { type Movie } from "../../shared/models";
+import { useState } from "react";
+import { Movie } from "../../shared/models";
 import { _Button as Button } from "../shared/button/button";
 import {
-  MovieCardWrapper,
+  MovieButtonLoading,
+  MovieGridWrapper,
   MovieImage,
+  MovieImageLoading,
   MovieInfo,
-  MovieInfoWrapper,
+  MovieInfoLoading,
   MovieTitle,
+  MovieTitleLoading,
 } from "./movieCard.styles";
 
 export const _MovieCard = ({ ...props }: Movie) => {
+  const [loaded, setLoaded] = useState(false);
+
+  const handleImageLoad = () => {
+    setLoaded(true);
+  };
+
   return (
-    <MovieCardWrapper>
-      <MovieTitle>{props.title}</MovieTitle>
-      <MovieInfoWrapper>
-        <MovieImage
-          src={
-            "https://www.nbmchealth.com/wp-content/uploads/2018/04/default-placeholder.png"
-          }
-          alt={props.title + " image"}
-        />
+    <MovieGridWrapper>
+      {loaded ? <MovieTitle>{props.title}</MovieTitle> : <MovieTitleLoading />}
+      {!loaded && <MovieImageLoading />}
+      <MovieImage
+        src={
+          props.posterUrl
+            ? props.posterUrl
+            : "https://www.nbmchealth.com/wp-content/uploads/2018/04/default-placeholder.png"
+        }
+        alt={props.title + " image"}
+        onLoad={handleImageLoad}
+        style={{ display: loaded ? "block" : "none" }}
+      />
+      {loaded ? (
         <MovieInfo>Year: {props.year}</MovieInfo>
+      ) : (
+        <MovieInfoLoading />
+      )}
+      {loaded ? (
         <Button
           size={"small"}
           variant={"contained"}
@@ -31,7 +50,9 @@ export const _MovieCard = ({ ...props }: Movie) => {
           }}
           style={{ gridArea: "button" }}
         />
-      </MovieInfoWrapper>
-    </MovieCardWrapper>
+      ) : (
+        <MovieButtonLoading />
+      )}
+    </MovieGridWrapper>
   );
 };

--- a/Frontend/src/pages/movies/movies.container.tsx
+++ b/Frontend/src/pages/movies/movies.container.tsx
@@ -35,7 +35,6 @@ export const _Movies = (props: MovieProps) => {
             onChange={handlePageChange}
             size="large"
           />
-
           <StyledMovieGrid container>
             {movies.map((movie) => (
               <StyledMovieCardWrapper key={movie.id}>
@@ -45,7 +44,7 @@ export const _Movies = (props: MovieProps) => {
           </StyledMovieGrid>
 
           <Pagination
-            count={Math.ceil(total / 10)}
+            count={Math.ceil(total / 12)}
             page={page}
             defaultPage={1}
             onChange={handlePageChange}

--- a/Frontend/src/pages/movies/movies.props.ts
+++ b/Frontend/src/pages/movies/movies.props.ts
@@ -6,7 +6,7 @@ export interface MovieProps {
   isLoading: boolean;
   page: number;
   total: number;
-  getMovieWith: (movieId: number) => void;
   getMovies: (skip: number, take: number) => void;
+  getMovieWith: (movieId: number) => void;
   setPage: (page: number) => void;
 }

--- a/Frontend/src/pages/movies/movies.tsx
+++ b/Frontend/src/pages/movies/movies.tsx
@@ -18,9 +18,9 @@ const mapStateToProps = (state: ApplicationState) => ({
 const mapDispatchToProps = (dispatch: AppDispatch) => {
   return bindActionCreators(
     {
+      setPage,
       getMovieWith: services.getMovieWith,
       getMovies: services.getMovies,
-      setPage,
     },
     dispatch,
   );

--- a/Frontend/src/services/endpoints.ts
+++ b/Frontend/src/services/endpoints.ts
@@ -1,7 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 const baseUrl = process.env.REACT_APP_API_URL!;
+const omdbApiKey = process.env.REACT_APP_OMDB_API_KEY!;
+const omdbUrl = "https://www.omdbapi.com/";
 export const endpoints = {
   getMovies: (skip: number, take: number) => `${baseUrl}/Movie/${skip}/${take}`,
   getMovieWith: (id: number) => `${baseUrl}/Movie/${id}`,
-  getMovieReviews: (id: number) => `${baseUrl}/movieReviews/`,
+  getOmdbMovieWith: (id: number) => `${omdbUrl}?i=tt${id}&apikey=${omdbApiKey}`,
 };

--- a/Frontend/src/shared/models/movie.ts
+++ b/Frontend/src/shared/models/movie.ts
@@ -2,4 +2,5 @@ export interface Movie {
   id: number;
   title: string;
   year: number;
+  posterUrl?: string;
 }


### PR DESCRIPTION
Adding api calls for movie images:

1. Adding api key to access free api for images
2. Adding default placeholder image when api is not providing an image for movie
3. Changes to movieCard -> adding onLoad to the image
4. Adding skeleton grid parts when images are not yet loaded to minimalize jumping of items when an image loads last